### PR TITLE
GC_TECH-261 [@gemcook/modal] ばつアイコンの z-index を9999にする。

### DIFF
--- a/src/styles/Modal.scss
+++ b/src/styles/Modal.scss
@@ -18,6 +18,8 @@
 
   .w__close {
     position: relative;
+    z-index: 9999;
+    width: 18px;
     cursor: pointer;
     outline: none;
 


### PR DESCRIPTION
https://gemcook.backlog.jp/view/GC_TECH-261